### PR TITLE
add required standard header files in the expected directory

### DIFF
--- a/.github/workflows/makefile-ci.yml
+++ b/.github/workflows/makefile-ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Place header files in expected directory
       run: |
         mkdir -p /opt/homebrew/Cellar
-        ls /opt/homebrew/opt/llvm/lib/clang/10.0.1
+        cp -r /opt/homebrew/opt/llvm/lib/clang/10.0.1/include /opt/homebrew/Cellar/llvm/18.1.6/lib/clang/18/include
             
 
     - uses: actions/checkout@v4

--- a/.github/workflows/makefile-ci.yml
+++ b/.github/workflows/makefile-ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Place header files in expected directory
       run: |
         mkdir -p /opt/homebrew/Cellar
-        ls /opt/homebrew/opt/llvm
+        ls /opt/homebrew/opt/llvm/lib/clang
             
 
     - uses: actions/checkout@v4

--- a/.github/workflows/makefile-ci.yml
+++ b/.github/workflows/makefile-ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Place header files in expected directory
       run: |
         mkdir -p /opt/homebrew/Cellar
-        ls /opt/homebrew/opt/llvm/lib/clang
+        ls /opt/homebrew/opt/llvm/lib/clang/10.0.1
             
 
     - uses: actions/checkout@v4

--- a/.github/workflows/makefile-ci.yml
+++ b/.github/workflows/makefile-ci.yml
@@ -22,7 +22,8 @@ jobs:
     - name: Place header files in expected directory
       run: |
         mkdir -p /opt/homebrew/Cellar/llvm/18.1.6/lib/clang/18/include
-        cp -r /opt/homebrew/opt/llvm/lib/clang/10.0.1/include/ /opt/homebrew/Cellar/llvm/18.1.6/lib/clang/18/include/
+        cp /opt/homebrew/opt/llvm/lib/clang/10.0.1/include/stdarg.h /opt/homebrew/Cellar/llvm/18.1.6/lib/clang/18/include/
+        cp /opt/homebrew/opt/llvm/lib/clang/10.0.1/include/stdint.h /opt/homebrew/Cellar/llvm/18.1.6/lib/clang/18/include/
             
 
     - uses: actions/checkout@v4

--- a/.github/workflows/makefile-ci.yml
+++ b/.github/workflows/makefile-ci.yml
@@ -21,8 +21,8 @@ jobs:
 
     - name: Place header files in expected directory
       run: |
-        mkdir -p /opt/homebrew/Cellar
-        cp -r /opt/homebrew/opt/llvm/lib/clang/10.0.1/include /opt/homebrew/Cellar/llvm/18.1.6/lib/clang/18/include
+        mkdir -p /opt/homebrew/Cellar/llvm/18.1.6/lib/clang/18/include
+        cp -r /opt/homebrew/opt/llvm/lib/clang/10.0.1/include/ /opt/homebrew/Cellar/llvm/18.1.6/lib/clang/18/include/
             
 
     - uses: actions/checkout@v4

--- a/.github/workflows/makefile-ci.yml
+++ b/.github/workflows/makefile-ci.yml
@@ -2,7 +2,7 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "ci-testing" ]
   pull_request:
     branches: [ "main" ]
 
@@ -18,6 +18,12 @@ jobs:
       with:
         version: "10.0"
         directory: /opt/homebrew/opt/llvm
+
+    - name: Place header files in expected directory
+      run: |
+        mkdir -p /opt/homebrew/Cellar
+        ls /opt/homebrew/opt/llvm
+            
 
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
The clang include flags set in the Makefile expect the standard header files to be present in `/opt/homebrew/Cellar/llvm/18.1.6/lib/clang/18/include/`, but it is present in `/opt/homebrew/opt/llvm/lib/clang/10.0.1/include/` inside of the macOS runner running the actions workflow.